### PR TITLE
Use higher contrast for scrollbar

### DIFF
--- a/gtk-3.0/colors_ami.css
+++ b/gtk-3.0/colors_ami.css
@@ -2,6 +2,7 @@
 @define-color bg_color #929793;
 @define-color bg_color_darken #828782;
 @define-color bg_color_lighten #B2B7B3;
+@define-color bg_color_halfblack #494B49; /* use instead of stipple */
 @define-color fg_color #111;
 @define-color fg_color_lighten #888;
 @define-color base_color #929793;

--- a/gtk-3.0/colors_amiblue.css
+++ b/gtk-3.0/colors_amiblue.css
@@ -2,6 +2,7 @@
 @define-color bg_color #383c4a;
 @define-color bg_color_darken #282c3a;
 @define-color bg_color_lighten #484c6a;
+@define-color bg_color_halfblack #1d1f26; /* use instead of stipple */
 @define-color fg_color #aaccff;
 @define-color fg_color_lighten #ddeeff;
 @define-color base_color #383c4a;

--- a/gtk-3.0/widgets/scrollbar.css
+++ b/gtk-3.0/widgets/scrollbar.css
@@ -10,6 +10,7 @@ scrollbar {
     -GtkScrollbar-has-backward-stepper: true;
     -GtkScrollbar-has-forward-stepper: true;
 
+    background-color: @bg_color_halfblack;
     border-style: solid;
     border-width: 1px;
     padding: 1px;


### PR DESCRIPTION
Grey scroll-bar on grey background is hard see with peripheral vision (scrolling fullscreen documents).

![scrollbar_contrast](https://user-images.githubusercontent.com/1869379/31581819-32cd6ec8-b1bf-11e7-8b3a-0000aeb30d14.png)

Original workbench uses black stipple, match this with half-black color.

![scrollbar_contrast_wb_example](https://user-images.githubusercontent.com/1869379/31581848-e09b303a-b1bf-11e7-8f9b-75e6dc6e6789.jpg)
