### PR TITLE
Fix scale marks background

### DIFF
--- a/gtk-3.0/widgets/scale.css
+++ b/gtk-3.0/widgets/scale.css
@@ -37,7 +37,7 @@ scale slider:disabled {
 }
 
 scale mark {
-    background-color: @fg_color;
+    background-color: @bg_color;
     margin-top: 2px;
     min-height: 5px;
     min-width: 1px;


### PR DESCRIPTION
Scale marks background was cleverly set to @fg_color, presumably as a
result of insufficient caffeine being applied to the programming entity.

Set scale marks background to @bg_color after applying sufficient
caffeine.

Signed-off-by: Alexandru Lazar <alazar@startmail.com>